### PR TITLE
Add prefer-ip4 option to jinja2 template

### DIFF
--- a/templates/unbound.conf.j2
+++ b/templates/unbound.conf.j2
@@ -67,6 +67,9 @@ server:
 
     do-ip4: {{ unbound_do_ip4 }}
     do-ip6: {{ unbound_do_ip6 }}
+{% if unbound_prefer_ip4 is defined %}
+    prefer-ip4: {{ unbound_prefer_ip4 }}
+{% endif %}
 {% if unbound_prefer_ip6 is defined %}
     prefer-ip6: {{ unbound_prefer_ip6 }}
 {% endif %}


### PR DESCRIPTION
Option to also enable preferring of IPv4 for sending queries over IPv6. 

Taken from documentation:

```
If enabled, prefer IPv4 transport for sending DNS queries to internet
nameservers. Default is no.  Useful if the IPv6 netblock the server has,
the entire /64 of that is not owned by one operator and the reputation of
the netblock /64 is an issue, using IPv4 then uses the IPv4 filters that
the upstream servers have.
```