### PR TITLE
Allow the possibility to include other config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,14 @@
 ---
-
 unbound_conf_path: "/etc/unbound/unbound.conf"
 unbound_enable_service: true
 unbound_service_name: "unbound"
+
+
+### Includes ###
+
+unbound_pre_includes: []
+unbound_post_includes: []
+
 
 ### Server ###
 

--- a/templates/unbound.conf.j2
+++ b/templates/unbound.conf.j2
@@ -1,5 +1,9 @@
 #{{ ansible_managed }}
 
+{% for include in unbound_pre_includes %}
+include: {{ include }}
+{% endfor %}
+
 server:
     verbosity: {{ unbound_verbosity }}
     username: "{{ unbound_username }}"
@@ -465,3 +469,7 @@ cachedb:
     redis-timeout: {{ unbound_cachedb_redis_timeout }}
     {% endif %}
 {% endif %}
+
+{% for include in unbound_post_includes %}
+include: {{ include }}
+{% endfor %}


### PR DESCRIPTION
Hello,

I find myself needing to include unbound configuration files, for instance, when I want to load DNS Blacklists from https://pgl.yoyo.org/adservers/.

Not sure this is the best way to do it, but the included parameters could potentielly be overriden through the main config' file, so you can choose if you want to include it before or after your regular configuration.