### PR TITLE
[feature] add support of AltLinux 7

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,9 @@ galaxy_info:
     - name: AlmaLinux
       versions:
         - 8
+    - name: AltLinux
+      versions:
+        - 7
     - name: Archlinux
 
   galaxy_tags:

--- a/vars/Altlinux.yml
+++ b/vars/Altlinux.yml
@@ -1,0 +1,17 @@
+---
+
+unbound_conf_path: "/var/lib/unbound/unbound.conf"
+
+unbound_directory: "/var/lib/unbound/"
+
+unbound_packages:
+  - "unbound"
+
+unbound_username: "_unbound"
+
+unbound_reloaded_state: "reloaded"
+
+unbound_service_name: "unbound.service"
+
+# vim: set ts=2 sw=2:
+


### PR DESCRIPTION
AltLinux has several differences from default configuration:
 - directory path
 - systemd service name
 - unix account name

This commit allows to use this role on AltLinux (https://en.altlinux.org/Main_Page), tested on AltLinux 7.0.5 SPT