### PR TITLE
[fix] make force restart in case of unsuccessful reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
 
 - name: restart unbound
-  become: true
-  service:
-    name: "{{ unbound_service_name }}"
-    state: "{{ unbound_reloaded_state }}"
+  ansible.builtin.include_tasks: tasks/restart_unbound.yml
 
 # vim: set ts=2 sw=2:

--- a/tasks/restart_unbound.yml
+++ b/tasks/restart_unbound.yml
@@ -1,0 +1,14 @@
+- block:
+   - name: restart unbound gracefully
+     register: _handler_status
+     ignore_errors: true
+     service:
+       name: "{{ unbound_service_name }}"
+       state: "{{ unbound_reloaded_state }}"
+
+   - name: force restart unbound
+     when: _handler_status | default({}) is failed
+     service:
+       name: "{{ unbound_service_name }}"
+       state: "restarted"
+  become: true


### PR DESCRIPTION
This fix makes second try to restart service if reload is failed.

After installation of package daemon "unbound" may be started with default settings. By default, process will start listen for control socket bound to localhost. On dual-stack systems (IPv4+IPv6) it may results into listening IPv6 loopback address ([::1]) when unbound-reload tries to access IPv4. As result unbound-reload returns error.

To avoid break of scripts let's try to restart in case of unsuccessful reload.

Ansible supports error handling via block-rescue, but it seems that support inside task handlers is limited. At least it doesn't work for me. That's why error is handled by "ignore_errors + when".