### PR TITLE
[fix] add support for Oracle Linux

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,6 +26,9 @@ galaxy_info:
       versions:
         - 7
     - name: Archlinux
+    - name: OracleLinux
+      versions:
+        - 8
 
   galaxy_tags:
     - networking

--- a/vars/OracleLinux.yml
+++ b/vars/OracleLinux.yml
@@ -1,0 +1,8 @@
+---
+
+unbound_packages:
+  - unbound
+
+unbound_reloaded_state: "restarted"
+
+# vim: set ts=2 sw=2:


### PR DESCRIPTION
This commit allows to use role for Oracle Linux.

By default, it tries to find approapriate variables and tries to use RedHat's ones. But role execution fails with missing trusted-key.key.

Tested on OEL 8.5.