### PR TITLE
fix: set logfile with use-syslog: no

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Check in the `unbound.conf.j2` template if the option is listed, otherwise do
 not hesitate to open an issue and I will include it (it is possible that
 options brought by a new unbound release would be missing here).
 
+When setting `unbound_logfile`, `use-syslog` will be set as "no" at the same time because it will otherwise overwrite the custom logfile config. ref: [unbound doc](https://linux.die.net/man/5/unbound.conf).
+
 Dependencies
 ------------
 

--- a/templates/unbound.conf.j2
+++ b/templates/unbound.conf.j2
@@ -8,9 +8,8 @@ server:
     verbosity: {{ unbound_verbosity }}
     username: "{{ unbound_username }}"
     directory: "{{ unbound_directory }}"
-{% if unbound_use_syslog is defined and unbound_use_syslog == "yes" %}
-    use-syslog: {{ unbound_use_syslog }}
-{% elif unbound_logfile is defined %}
+{% if unbound_logfile is defined %}
+    use-syslog: no
     logfile: {{ unbound_logfile }}
 {% endif %}
 {% if unbound_log_identity is defined %}


### PR DESCRIPTION
The previous template doesn't work when setting logfile because unbound use-syslog is default to "yes" and it would overwrite logfile option. ref: https://linux.die.net/man/5/unbound.conf -- see "use-syslog"

For a customized logfile to work, the config needs to be
```
use-syslog: no
logfile: <logfile_location>
```

There are many ways to make it work. Mine assumes that if a user set "logfile" then it's very likely that the user would want it not be overwritten by use-syslog, therefore I didn't give user options to modify use-syslog.

Please let me know what you think, thanks!