### PR TITLE
Added comment filter to ansible_managed var in unbound.conf.j2.

### DIFF
--- a/templates/unbound.conf.j2
+++ b/templates/unbound.conf.j2
@@ -1,4 +1,4 @@
-#{{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for include in unbound_pre_includes %}
 include: {{ include }}


### PR DESCRIPTION
The current implementation of the {{ ansible_managed }} variable does not work well for anyone that has customized that variable to include multiple lines of content. Effectively it renders the comment hash on the first line, but any other line defined in the ansible_managed var was added to the template without a comment has.

This is easily improved by removing the comment hash from the template and using the comment filter. It will automatically use the appropriate comment style for the file (bash, json, etc) and if you have multiple lines defined it will comment them all automatically.